### PR TITLE
fix(UI) use correct color codes (MON-14512)

### DIFF
--- a/global-health/src/global_health_host.ihtml
+++ b/global-health/src/global_health_host.ihtml
@@ -29,7 +29,7 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td> <span class="ListColCenter state_badge" style="background:#87BD23"></span> <b> Ok </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#88B917"></span> <b> Ok </b> </td>
                         <td> {$hosts.UP.value} </td>
                         <td> {$hosts.UP.acknowledged} </td>
                         <td> {$hosts.UP.downtime} </td>
@@ -37,7 +37,7 @@
                     </tr>
                     <tr>
 
-                        <td> <span class="ListColCenter state_badge" style="background:#ED1C24"></span> <b> Down </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#E00B3D"></span> <b> Down </b> </td>
                         <td> {$hosts.DOWN.value} </td>
                         <td> {$hosts.DOWN.acknowledged} </td>
                         <td> {$hosts.DOWN.downtime} </td>
@@ -45,14 +45,14 @@
                     </tr>
                     <tr>
 
-                        <td> <span class="ListColCenter state_badge" style="background: #CDCDCD "></span> <b> Unreachable </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background: #818285"></span> <b> Unreachable </b> </td>
                         <td> {$hosts.UNREACHABLE.value} </td>
                         <td> {$hosts.UNREACHABLE.acknowledged} </td>
                         <td> {$hosts.UNREACHABLE.downtime} </td>
                         <td> {$hosts.UNREACHABLE.percent} </td>
                     </tr>
                     <tr>
-                        <td> <span class="ListColCenter state_badge" style="background:#2AD1D4 "></span> <b> Pending </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#2AD1D4"></span> <b> Pending </b> </td>
                         <td> {$hosts.PENDING.value} </td>
                         <td> {$hosts.PENDING.acknowledged} </td>
                         <td> {$hosts.PENDING.downtime} </td>
@@ -108,7 +108,7 @@
             },
             labels:['Up', 'Down', 'Unreachable', 'Pending'],
             series:[UP, DOWN, UNREACHABLE, PENDING],
-            colors:['#87BD23', '#ED1C24', '#CDCDCD','#2AD1D4']
+            colors:['#88B917', '#E00B3D', '#818285','#2AD1D4']
         };
         //The legend appear when the user hide the table because the table include it originally 
         {/literal}{if $preferences.hide_table}            

--- a/global-health/src/global_health_service.ihtml
+++ b/global-health/src/global_health_service.ihtml
@@ -29,28 +29,28 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td> <span class="ListColCenter state_badge" style="background:#87BD23"></span> <b> Ok </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#88B917"></span> <b> Ok </b> </td>
                         <td> {$services.OK.value} </td>
                         <td> {$services.OK.acknowledged} </td>
                         <td> {$services.OK.downtime} </td>
                         <td> {$services.OK.percent}</td>
                     </tr>
                     <tr>
-                        <td> <span class="ListColCenter state_badge" style="background:#FF9913"></span> <b> Warning </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#FF9A13"></span> <b> Warning </b> </td>
                         <td> {$services.WARNING.value} </td>
                         <td> {$services.WARNING.acknowledged} </td>
                         <td> {$services.WARNING.downtime} </td>
                         <td> {$services.WARNING.percent} </td>
                     </tr>
                     <tr>
-                        <td> <span class="ListColCenter state_badge" style="background:#ED1C24"></span> <b> Critical </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#E00B3D"></span> <b> Critical </b> </td>
                         <td> {$services.CRITICAL.value} </td>
                         <td> {$services.CRITICAL.acknowledged}</td>
                         <td> {$services.CRITICAL.downtime}</td>
                         <td> {$services.CRITICAL.percent}</td>
                     </tr>
                     <tr>
-                        <td> <span class="ListColCenter state_badge" style="background:#CDCDCD"></span> <b> Unknown </b> </td>
+                        <td> <span class="ListColCenter state_badge" style="background:#BCBDC0"></span> <b> Unknown </b> </td>
                         <td> {$services.UNKNOWN.value} </td>
                         <td> {$services.UNKNOWN.acknowledged} </td>
                         <td> {$services.UNKNOWN.downtime} </td>
@@ -114,7 +114,7 @@
             },
             labels:['Ok', 'Warning', 'Critical','Unknown', 'Pending'],
             series:[OK, WARNING, CRITICAL,UNKNOWN, PENDING],
-            colors:['#87BD23','#FF9913', '#ED1C24', '#CDCDCD','#2AD1D4']
+            colors:['#88B917','#FF9A13', '#E00B3D', '#BCBDC0','#2AD1D4']
         };
         //The legend appear when the user hide the table because the table include it originally 
         {/literal}{if $preferences.hide_table}            


### PR DESCRIPTION
Hi,

Some color `#codes` are wrong, with for example, depending on the widgets, _pending_ color instead of _unavailable_ etc...
Let's then properly update all color codes once for all according to the Centreon-2 theme (`www/Themes/Centreon-2/style.css`).

Pleaase backport at least up to 19.10.x.

As well as all other color-related PRs :
https://github.com/centreon/centreon-widget-grid-map/pull/20
https://github.com/centreon/centreon-widget-hostgroup-monitoring/pull/36
https://github.com/centreon/centreon-widget-host-monitoring/pull/94
https://github.com/centreon/centreon-widget-servicegroup-monitoring/pull/31
https://github.com/centreon/centreon-widget-service-monitoring/pull/155

Thank you very much 👍

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)