### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/global-health/configs.xml
+++ b/global-health/configs.xml
@@ -4,7 +4,7 @@
         <email>contact@centreon.com</email>
         <website>http://www.centreon.com</website>
         <description>This pie chart widget displays the resource distribution by status (percentage), also indicating the total number of resources by status or by acknowledged and downtime state. This widget is available for hosts or for services. It is also possible to filter for a subset of resources.</description>
-        <version>21.10.0-beta.1</version>
+        <version>21.10.0</version>
         <keywords>centreon, widget, global, health</keywords>
         <screenshot></screenshot>
         <thumbnail>./widgets/global-health/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix